### PR TITLE
Remove the need for copying urls

### DIFF
--- a/CloudFormationTemplate/CreateAmazonMQWorkshop.yaml
+++ b/CloudFormationTemplate/CreateAmazonMQWorkshop.yaml
@@ -1,5 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: AWS CloudFormation template to launch resources for the Amazon MQ workshop.
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -16,6 +17,7 @@ Metadata:
           default: Lab Configuration
         Parameters:
           - LabLevel
+          - EnvironmentOwnerType
     ParameterLabels:
       AmazonMQBrokerUser:
         default: Broker Username
@@ -23,6 +25,9 @@ Metadata:
         default: Broker Password
       LabLevel:
         default: Lab Level
+      EnvironmentOwnerType:
+        default: Environment Type
+      
 Parameters:
   CIDR:
     Description: CIDR block, from which the access to the EC2 instance is allowed.
@@ -40,19 +45,35 @@ Parameters:
   AmazonMQBrokerPassword:
     Description: The password to access the Amazon MQ broker. Min 12 characters
     Type: String
+    Default: workshopUser
     MinLength: 12
     ConstraintDescription: The Amazon MQ broker password is required !
     NoEcho: true
   LabLevel:
     Type: String
-    Default: basic
+    Default: all
     AllowedValues:
       - basic
       - advanced
       - all
     Description: Enter basic for Labs 1-8, advanced for Labs 9 and above or all for
       All labs.
+  EnvironmentOwnerType:
+    Type: String
+    AllowedValues:
+      - user
+      - assumed-role
+    Default: assumed-role
+    Description: >-
+      Type of access the owner of environment has.  The default is an assumed-role
+      which is used by the workshop event engine.  If testing this in your own account this should
+      be "user".
+
 Conditions:
+  UseAssumedRole:
+    Fn::Equals:
+      - !Ref EnvironmentOwnerType
+      - assumed-role
   AdvancedLab: !Not
     - !Equals
       - !Ref 'LabLevel'
@@ -60,6 +81,7 @@ Conditions:
   BasicLab: !Equals
       - !Ref 'LabLevel'
       - basic
+
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -200,10 +222,7 @@ Resources:
     Type: AWS::AmazonMQ::Broker
     Condition: BasicLab
     Properties:
-      BrokerName: !Join
-        - '-'
-        - - !Ref 'AWS::StackName'
-          - Broker
+      BrokerName: Broker
       EngineType: ActiveMQ
       EngineVersion: 5.15.9
       HostInstanceType: mq.t2.micro
@@ -228,10 +247,7 @@ Resources:
     Type: AWS::AmazonMQ::Broker
     Condition: AdvancedLab
     Properties:
-      BrokerName: !Join
-        - '-'
-        - - !Ref 'AWS::StackName'
-          - Broker
+      BrokerName: Broker
       EngineType: ActiveMQ
       EngineVersion: 5.15.9
       HostInstanceType: mq.m5.large
@@ -255,11 +271,7 @@ Resources:
   Broker1:
     Condition: AdvancedLab
     Properties:
-      BrokerName:
-        Fn::Join:
-        - ''
-        - - Ref: AWS::StackName
-          - -Broker1
+      BrokerName: NoB1
       DeploymentMode: ACTIVE_STANDBY_MULTI_AZ
       EngineType: ACTIVEMQ
       EngineVersion: 5.15.9
@@ -285,11 +297,7 @@ Resources:
     Condition: AdvancedLab
     Properties:
       AutoMinorVersionUpgrade: false
-      BrokerName:
-        Fn::Join:
-        - ''
-        - - Ref: AWS::StackName
-          - -Broker2
+      BrokerName: NoB2
       DeploymentMode: ACTIVE_STANDBY_MULTI_AZ
       EngineType: ACTIVEMQ
       EngineVersion: 5.15.9
@@ -315,11 +323,7 @@ Resources:
     Condition: AdvancedLab
     Properties:
       AutoMinorVersionUpgrade: false
-      BrokerName:
-        Fn::Join:
-        - ''
-        - - Ref: AWS::StackName
-          - -Broker3
+      BrokerName: NoB3
       DeploymentMode: ACTIVE_STANDBY_MULTI_AZ
       EngineType: ACTIVEMQ
       EngineVersion: 5.15.9
@@ -1342,9 +1346,18 @@ Resources:
     Properties:
       AutomaticStopTimeMinutes: 30
       Description: MQ Client Workspace
-      InstanceType: t2.micro
-      Name: MQClient
+      InstanceType: m4.large
+      Name:
+        Fn::Join:
+        - ''
+        - - Ref: AWS::StackName
+          - MQClient
       Repositories:
         - PathComponent: /amazon-mq-workshop
           RepositoryUrl: https://github.com/aws-samples/amazon-mq-workshop.git
       SubnetId: !Ref 'PublicSubnet1'
+      OwnerArn: 
+        Fn::If:
+          - UseAssumedRole
+          - !Sub "arn:aws:sts::${AWS::AccountId}:assumed-role/TeamRole/MasterKey"
+          - !Ref "AWS::NoValue"

--- a/setup.sh
+++ b/setup.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 cd ~/environment
+echo "Installing jq..."
+sudo yum install -y jq > /dev/null 2>&1
 java_version=`java -version |& awk -F '"' '/version/ {print $2}'`
 if [[ "$java_version" =~ .*1\.8.*  ]]; then
     echo "Java is up to date"
 else 
-    echo "Updating java to 1.8"
+    echo "Updating java to 1.8..."
     wget https://d3pxv6yz143wms.cloudfront.net/8.222.10.1/java-1.8.0-amazon-corretto-devel-1.8.0_222.b10-1.x86_64.rpm > /dev/null 2>&1
     sudo yum localinstall -y java-1.8.0-amazon-corretto-devel-1.8.0_222.b10-1.x86_64.rpm > /dev/null 2>&1
 fi
@@ -16,7 +18,7 @@ mvn_version=`mvn -version |& awk '/Apache Maven/ {print $3 }'`
 if [[ "$mvn_version" =~ .*3\.6.* ]]; then
     echo "Maven is up to date"
 else 
-    echo "Updating maven to 3.6"
+    echo "Updating maven to 3.6..."
     wget http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz > /dev/null 2>&1
     tar zxvf apache-maven-3.6.1-bin.tar.gz > /dev/null 2>&1
     echo "export PATH=~/environment/apache-maven-3.6.1/bin:$PATH" >> ~/.bashrc
@@ -26,12 +28,29 @@ if [[ -d ~/environment/activemq-perftest ]];
 then
     echo "Maven performance tool kit exists"
 else 
-    echo "Installing maven performance plugin"
+    echo "Installing maven performance plugin..."
     svn checkout http://svn.apache.org/repos/asf/activemq/sandbox/activemq-perftest/ activemq-perftest > /dev/null 2>&1
     sed -i 's/5.8-SNAPSHOT/5.15.9/g' ~/environment/activemq-perftest/pom.xml 
     mkdir ~/environment/activemq-perftest/reports
 fi
+echo "Getting broker urls..."
+brokerId=`aws mq list-brokers | jq '.BrokerSummaries[] | select(.BrokerName=="Broker") | {id:.BrokerId}' | grep "id" | cut -d '"' -f4`
+nob1Id=`aws mq list-brokers | jq '.BrokerSummaries[] | select(.BrokerName=="NoB1") | {id:.BrokerId}' | grep "id" | cut -d '"' -f4`
+nob2Id=`aws mq list-brokers | jq '.BrokerSummaries[] | select(.BrokerName=="NoB2") | {id:.BrokerId}' | grep "id" | cut -d '"' -f4`
+nob3Id=`aws mq list-brokers | jq '.BrokerSummaries[] | select(.BrokerName=="NoB3") | {id:.BrokerId}' | grep "id" | cut -d '"' -f4`
+url=`aws mq describe-broker --broker-id=$brokerId | jq '.BrokerInstances[].Endpoints[0]' | xargs -n 2 | awk '{ print "failover("$1","$2")" }'`
+mesh1url=`aws mq describe-broker --broker-id=$nob1Id | jq '.BrokerInstances[].Endpoints[0]' | xargs -n 2 | awk '{ print "failover("$1","$2")" }'`
+mesh2url=`aws mq describe-broker --broker-id=$nob2Id | jq '.BrokerInstances[].Endpoints[0]' | xargs -n 2 | awk '{ print "failover("$1","$2")" }'`
+mesh3url=`aws mq describe-broker --broker-id=$nob3Id | jq '.BrokerInstances[].Endpoints[0]' | xargs -n 2 | awk '{ print "failover("$1","$2")" }'`
+echo "Saving broker urls..."
 
+echo "perfurl=\"$url\"" >> ~/.bashrc; 
+echo "url=\"$url\"" >> ~/.bashrc; 
+echo "mesh1url=\"$mesh1url\"" >> ~/.bashrc; 
+echo "mesh2url=\"$mesh2url\"" >> ~/.bashrc; 
+echo "mesh3url=\"$mesh3url\"" >> ~/.bashrc; 
+
+echo "Accessing parameter store..."
 userPassword=`aws ssm get-parameter --name "MQBrokerUserPassword" |& grep "Value\|ParameterNotFound"`
 if [[ $userPassword =~ .*ParameterNotFound.* ]];
 then
@@ -40,6 +59,11 @@ else
     brokerUser=`echo $userPassword | sed 's/"//g' | sed 's/Value://g' | cut -d',' -f1 | sed 's/ //g'`
     brokerPassword=`echo $userPassword | sed 's/"//g' | sed 's/Value://g' | cut -d',' -f2`
 fi
+
+echo "brokerUser=\"$brokerUser\"" >> ~/.bashrc; 
+echo "brokerPassword=\"$brokerPassword\"" >> ~/.bashrc; 
+
+source ~/.bashrc
 
 if [[ ! -z $perfurl ]]; 
 then
@@ -50,4 +74,4 @@ printf "\nfactory.brokerURL=$perfurl\n" >> ~/environment/amazon-mq-workshop/open
 printf "factory.userName=$brokerUser\n" >> ~/environment/amazon-mq-workshop/openwire-consumer.properties
 printf "factory.password=$brokerPassword\n" >> ~/environment/amazon-mq-workshop/openwire-consumer.properties
 fi
-
+echo "Done."


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the dry runs, often we are wasting close to 20 mins in figuring out how to get the failover url. So we decided to make this automatic. The only commands a participant would need to run are running setup.sh and sourcing .bashrc (or open a new terminal). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
